### PR TITLE
fixed array.traverse issue due to unexpected array.concat behavior if…

### DIFF
--- a/instances/array.js
+++ b/instances/array.js
@@ -59,7 +59,7 @@ Object.defineProperty(Array.prototype, 'ap',{
 
 var _traverse = function(f, point) {
   var cons_f = function(ys, x){
-    return f(x).map(function(x){ return function(y){ return y.concat(x); } }).ap(ys);
+    return f(x).map(function(x){ return function(y){ var t = y.concat(); t.push(x); return t; } }).ap(ys);
   }
   return this.reduce(cons_f, point([]));
 };

--- a/test/array.js
+++ b/test/array.js
@@ -28,4 +28,11 @@ describe('Array', function(){
   it('is foldable', function() {
     assert.deepEqual(foldMap(monoids.Sum, [1,2,3]), monoids.Sum(6))
   });
+
+  it('is traversable if function return an array', function () {
+    var f = function(x){ return Maybe([x]); }
+    var xs = [1,2];
+    assert.deepEqual(traverse(f, Maybe.of, xs), Maybe([[1],[2]]));
+  })
+
 });


### PR DESCRIPTION
If the traverse function return an array in container, it should return array of array in container, but currently it is a flat array in container which is unexpected IMO.  

e.g.: traverse(x=>Maybe.of([x]), Maybe.of, [1,2]) // should be [[1], [2]], but currently it was [1,2]

The whole reason of this issue is because the built-in concat method of array works differently for the type of passing parameter: 
- if passing an non-array, it will push, like [1].concat(2) // => [1,2]
- if passing an array, it will concat, like [].concat([2]) // => [1,2]

Hopefully, it makes sense. 
